### PR TITLE
Added DAC initialisation code to daemon.

### DIFF
--- a/source/daemon/src/daemon.cpp
+++ b/source/daemon/src/daemon.cpp
@@ -405,6 +405,13 @@ Daemon::Daemon(QString username, QString password, QString new_gpsdevname, int n
     // 4ch DAC MCP4728
     dac = new MCP4728();
     if (dac->devicePresent()) {
+        MCP4728::DacChannel bias_voltage;
+        dac->readChannel(DAC_BIAS, bias_voltage);
+        if (bias_voltage.value == 0) {
+            setBiasVoltage(MuonPi::Config::Hardware::DAC::Voltage::bias);
+            setDacThresh(0, MuonPi::Config::Hardware::DAC::Voltage::threshold[0]);
+            setDacThresh(1, MuonPi::Config::Hardware::DAC::Voltage::threshold[1]);
+        }
         if (verbose>2) {
             qInfo()<<"MCP4728 device is present.";
             qDebug()<<"DAC registers / output voltages:";
@@ -440,6 +447,8 @@ Daemon::Daemon(QString username, QString password, QString new_gpsdevname, int n
     }
     dacThresh.push_back(tempThresh[0]);
     dacThresh.push_back(tempThresh[1]);
+
+
 
     biasVoltage = new_biasVoltage;
     if (biasVoltage<0. && dac->devicePresent()) {

--- a/source/daemon/src/daemon.cpp
+++ b/source/daemon/src/daemon.cpp
@@ -405,13 +405,6 @@ Daemon::Daemon(QString username, QString password, QString new_gpsdevname, int n
     // 4ch DAC MCP4728
     dac = new MCP4728();
     if (dac->devicePresent()) {
-        MCP4728::DacChannel bias_voltage;
-        dac->readChannel(DAC_BIAS, bias_voltage);
-        if (bias_voltage.value == 0) {
-            setBiasVoltage(MuonPi::Config::Hardware::DAC::Voltage::bias);
-            setDacThresh(0, MuonPi::Config::Hardware::DAC::Voltage::threshold[0]);
-            setDacThresh(1, MuonPi::Config::Hardware::DAC::Voltage::threshold[1]);
-        }
         if (verbose>2) {
             qInfo()<<"MCP4728 device is present.";
             qDebug()<<"DAC registers / output voltages:";

--- a/source/daemon/src/daemon.cpp
+++ b/source/daemon/src/daemon.cpp
@@ -443,9 +443,10 @@ Daemon::Daemon(QString username, QString password, QString new_gpsdevname, int n
 
 
     if (dac->devicePresent()) {
-        MCP4728::DacChannel bias_voltage;
-        dac->readChannel(DAC_BIAS, bias_voltage);
-        if (bias_voltage.value == 0) {
+        MCP4728::DacChannel eeprom_value;
+        eeprom_value.eeprom = true;
+        dac->readChannel(DAC_BIAS, eeprom_value);
+        if (eeprom_value.value == 0) {
             setBiasVoltage(MuonPi::Config::Hardware::DAC::Voltage::bias);
             setDacThresh(0, MuonPi::Config::Hardware::DAC::Voltage::threshold[0]);
             setDacThresh(1, MuonPi::Config::Hardware::DAC::Voltage::threshold[1]);

--- a/source/daemon/src/daemon.cpp
+++ b/source/daemon/src/daemon.cpp
@@ -449,6 +449,15 @@ Daemon::Daemon(QString username, QString password, QString new_gpsdevname, int n
     dacThresh.push_back(tempThresh[1]);
 
 
+    if (dac->devicePresent()) {
+        MCP4728::DacChannel bias_voltage;
+        dac->readChannel(DAC_BIAS, bias_voltage);
+        if (bias_voltage.value == 0) {
+            setBiasVoltage(MuonPi::Config::Hardware::DAC::Voltage::bias);
+            setDacThresh(0, MuonPi::Config::Hardware::DAC::Voltage::threshold[0]);
+            setDacThresh(1, MuonPi::Config::Hardware::DAC::Voltage::threshold[1]);
+        }
+    }
 
     biasVoltage = new_biasVoltage;
     if (biasVoltage<0. && dac->devicePresent()) {

--- a/source/library/include/config.h
+++ b/source/library/include/config.h
@@ -49,8 +49,8 @@ constexpr int deadtime { 8 };
 }
 namespace DAC {
 namespace Voltage {
-constexpr float bias {0.0};
-constexpr float threshold[2] {0.0, 0.0};
+constexpr float bias {0.5};
+constexpr float threshold[2] {0.1, 1.0};
 }
 }
 namespace GPIO::Clock::Measurement {

--- a/source/library/include/config.h
+++ b/source/library/include/config.h
@@ -47,6 +47,12 @@ constexpr int buffer_size { 50 };
 constexpr int pretrigger { 10 };
 constexpr int deadtime { 8 };
 }
+namespace DAC {
+namespace Voltage {
+constexpr float bias {0.0};
+constexpr float threshold[2] {0.0, 0.0};
+}
+}
 namespace GPIO::Clock::Measurement {
 constexpr int interval { 100 };
 constexpr int buffer_size { 500 };


### PR DESCRIPTION
Added code to the daemon which initialises the DAC if the read value from the bias voltage is 0.

There are no sane default values set as of now, this needs to be done at https://github.com/MuonPi/muondetector/blob/3328c4a60e64d11e90d64bf19d77af0c6bb498a0/source/library/include/config.h#L52-L53