### PR TITLE
migrate from paho-mqttpp to libmosquitto

### DIFF
--- a/source/daemon/CMakeLists.txt
+++ b/source/daemon/CMakeLists.txt
@@ -152,9 +152,6 @@ set_property(TARGET muondetector-login PROPERTY POSITION_INDEPENDENT_CODE 1)
 
 target_include_directories(muondetector-login PUBLIC
     $<BUILD_INTERFACE:${LIBRARY_INCLUDE_DIR}>)
-target_include_directories(muondetector-login PUBLIC
-    $<BUILD_INTERFACE:/usr/local/include/mqtt>
-    $<INSTALL_INTERFACE:include/mqtt>)
 
 target_link_directories(muondetector-login PUBLIC "${CMAKE_CURRENT_BINARY_DIR}/../lib/")
 target_link_libraries(muondetector-login
@@ -172,10 +169,6 @@ target_include_directories(muondetector-daemon PUBLIC
     $<BUILD_INTERFACE:${PROJECT_HEADER_DIR}>
     $<BUILD_INTERFACE:${LIBRARY_INCLUDE_DIR}>)
 
-target_include_directories(muondetector-daemon PUBLIC
-    $<BUILD_INTERFACE:/usr/local/include/mqtt>
-    $<INSTALL_INTERFACE:include/mqtt>
-    )
 
 target_link_directories(muondetector-daemon PUBLIC "${CMAKE_CURRENT_BINARY_DIR}/../lib/")
 target_link_libraries(muondetector-daemon
@@ -184,7 +177,7 @@ target_link_libraries(muondetector-daemon
     pigpiod_if2
     rt
     config++
-    paho-mqtt3c paho-mqtt3a paho-mqtt3cs paho-mqtt3as paho-mqttpp3
+    mosquitto
     muondetector
     )
 
@@ -220,7 +213,7 @@ install(PROGRAMS ${LOGIN_INSTALL_FILES} DESTINATION bin COMPONENT daemon)
 
 set(CPACK_GENERATOR "DEB")
 set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
-set(CPACK_DEBIAN_PACKAGE_DEPENDS "pigpiod, libpaho-mqttpp")
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "pigpiod")
 set(CPACK_RESOURCE_FILE_LICENSE "${PROJECT_CONFIG_DIR}/license")
 set(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA "${PROJECT_CONFIG_DIR}/preinst;${PROJECT_CONFIG_DIR}/postinst;${PROJECT_CONFIG_DIR}/prerm;${PROJECT_CONFIG_DIR}/conffiles")
 set(CPACK_PACKAGE_VENDOR "MuonPi.org")

--- a/source/daemon/CMakeLists.txt
+++ b/source/daemon/CMakeLists.txt
@@ -33,11 +33,7 @@ find_package(Qt5 COMPONENTS Network SerialPort REQUIRED)
 
 if(NOT WIN32) # added to make program editable in qt-creator on windows
 
-find_library(PAHO_MQTT3C paho-mqtt3c REQUIRED)
-find_library(PAHO_MQTT3A paho-mqtt3a REQUIRED)
-find_library(PAHO_MQTT3CS paho-mqtt3cs REQUIRED)
-find_library(PAHO_MQTT3AS paho-mqtt3as REQUIRED)
-find_library(PAHO_MQTTPP3 paho-mqttpp3 REQUIRED)
+find_library(MOSQUITTO mosquitto REQUIRED)
 
 find_library(CRYPTOPP crypto++ REQUIRED)
 find_library(CONFIGPP config++ REQUIRED)
@@ -164,7 +160,7 @@ target_link_directories(muondetector-login PUBLIC "${CMAKE_CURRENT_BINARY_DIR}/.
 target_link_libraries(muondetector-login
     Qt5::Network Qt5::SerialPort
     crypto++
-    paho-mqtt3c paho-mqtt3a paho-mqtt3cs paho-mqtt3as paho-mqttpp3
+    mosquitto
     muondetector
     )
 

--- a/source/gui/CMakeLists.txt
+++ b/source/gui/CMakeLists.txt
@@ -83,11 +83,7 @@ find_package(Qt5 COMPONENTS Network Svg Widgets Gui Quick QuickWidgets Qml REQUI
 
 if(NOT WIN32)
 
-find_library(PAHO_MQTT3C paho-mqtt3c REQUIRED)
-find_library(PAHO_MQTT3A paho-mqtt3a REQUIRED)
-find_library(PAHO_MQTT3CS paho-mqtt3cs REQUIRED)
-find_library(PAHO_MQTT3AS paho-mqtt3as REQUIRED)
-find_library(PAHO_MQTTPP3 paho-mqttpp3 REQUIRED)
+find_library(MOSQUITTO mosquitto REQUIRED)
 find_library(CRYPTOPP crypto++ REQUIRED)
 find_library(QWT_QT5 qwt-qt5 REQUIRED)
 
@@ -277,13 +273,9 @@ target_link_libraries(muondetector-gui
     Qt5::Network Qt5::Svg Qt5::Widgets Qt5::Gui Qt5::Quick Qt5::QuickWidgets Qt5::Qml
     muondetector
     pthread
-    paho-mqtt3c
-    paho-mqtt3a
-    paho-mqtt3cs
-    paho-mqtt3as
     crypto++
     qwt-qt5
-    paho-mqttpp3
+    mosquitto
     )
 
 endif()

--- a/source/library/CMakeLists.txt
+++ b/source/library/CMakeLists.txt
@@ -80,11 +80,7 @@ find_package(Qt5 COMPONENTS Network REQUIRED)
 
 if(NOT WIN32)
 
-find_library(PAHO_MQTT3C paho-mqtt3c REQUIRED)
-find_library(PAHO_MQTT3A paho-mqtt3a REQUIRED)
-find_library(PAHO_MQTT3CS paho-mqtt3cs REQUIRED)
-find_library(PAHO_MQTT3AS paho-mqtt3as REQUIRED)
-find_library(PAHO_MQTTPP3 paho-mqttpp3 REQUIRED)
+find_library(MOSQUITTO mosquitto REQUIRED)
 
 endif()
 
@@ -164,7 +160,7 @@ target_include_directories(muondetector PUBLIC
     ${Qt5Network_INCLUDE_DIRS}
     )
 else()
-target_link_libraries(muondetector Qt5::Network paho-mqtt3c paho-mqtt3a paho-mqtt3cs paho-mqtt3as paho-mqttpp3)
+target_link_libraries(muondetector Qt5::Network mosquitto)
 endif()
 
 install(TARGETS muondetector DESTINATION lib COMPONENT library)

--- a/source/library/include/config.h
+++ b/source/library/include/config.h
@@ -24,10 +24,13 @@ constexpr const char* file { "/etc/muondetector/muondetector.conf" };
 constexpr int event_count_deadtime_ticks { 50000 };
 
 namespace MQTT {
-constexpr const char* server { "116.202.96.181:1883" };
-constexpr int timeout { 30000 };
+constexpr const char* host { "116.202.96.181" };
+constexpr int port { 1883 };
+constexpr int timeout { 2000 };
 constexpr int qos { 1 };
 constexpr int keepalive_interval { 45 };
+constexpr const char* data_topic { "muonpi/data/" };
+constexpr const char* log_topic { "muonpi/log/" };
 }
 namespace Log {
 constexpr int interval { 1 };

--- a/source/library/include/mqtthandler.h
+++ b/source/library/include/mqtthandler.h
@@ -25,7 +25,7 @@ public:
         Error
     };
 
-    MqttHandler(const QString& station_ID, const int verbosity=0);
+    MqttHandler(const QString& station_id, const int verbosity=0);
     ~MqttHandler() override;
 
     //using QObject::QObject;
@@ -89,10 +89,10 @@ private:
     std::vector<std::string> m_topics {};
 
     bool m_mqttConnectionStatus { false };
-    std::string m_stationID { "0" };
+    std::string m_station_id { "0" };
     std::string m_username {};
     std::string m_password {};
-    std::string m_clientID {};
+    std::string m_client_id {};
 
     std::string m_data_topic { Config::MQTT::data_topic };
     std::string m_log_topic { Config::MQTT::log_topic };

--- a/source/library/src/mqtthandler.cpp
+++ b/source/library/src/mqtthandler.cpp
@@ -85,8 +85,8 @@ void MqttHandler::set_status(Status status)
     m_status = status;
 }
 
-MqttHandler::MqttHandler(const QString& station_ID, const int verbosity)
-    : m_stationID { station_ID.toStdString() }
+MqttHandler::MqttHandler(const QString& station_id, const int verbosity)
+    : m_station_id { station_id.toStdString() }
     , m_verbose { verbosity }
 {
     m_reconnect_timer.setInterval(Config::MQTT::timeout);
@@ -101,15 +101,18 @@ MqttHandler::~MqttHandler()
 }
 
 void MqttHandler::start(const QString& username, const QString& password){
-    //qInfo() << this->thread()->objectName() << " thread id (pid): " << syscall(SYS_gettid);
     m_username = username.toStdString();
     m_password = password.toStdString();
-    CryptoPP::SHA1 sha1;
-    std::string source = username.toStdString()+m_stationID;  //This will be randomly generated somehow
-    m_clientID = "";
-    CryptoPP::StringSource{source, true, new CryptoPP::HashFilter(sha1, new CryptoPP::HexEncoder(new CryptoPP::StringSink(m_clientID)))};
 
-    initialise(m_clientID);
+    m_data_topic += Config::MQTT::data_topic + m_username + "/" + m_station_id;
+    m_log_topic +=  Config::MQTT::log_topic + m_username + "/" + m_station_id;
+
+    CryptoPP::SHA1 sha1;
+    std::string source = username.toStdString()+m_station_id;  //This will be randomly generated somehow
+    m_client_id = "";
+    CryptoPP::StringSource{source, true, new CryptoPP::HashFilter(sha1, new CryptoPP::HexEncoder(new CryptoPP::StringSink(m_client_id)))};
+
+    initialise(m_client_id);
 
 
     mqttConnect();
@@ -123,7 +126,7 @@ void MqttHandler::mqttConnect(){
     qDebug() << "Trying to connect to MQTT.";
 
     if (m_mqtt == nullptr) {
-        initialise(m_clientID);
+        initialise(m_client_id);
     }
 
     m_tries++;

--- a/source/library/src/mqtthandler.cpp
+++ b/source/library/src/mqtthandler.cpp
@@ -104,8 +104,8 @@ void MqttHandler::start(const QString& username, const QString& password){
     m_username = username.toStdString();
     m_password = password.toStdString();
 
-    m_data_topic += Config::MQTT::data_topic + m_username + "/" + m_station_id;
-    m_log_topic +=  Config::MQTT::log_topic + m_username + "/" + m_station_id;
+    m_data_topic = Config::MQTT::data_topic + m_username + "/" + m_station_id;
+    m_log_topic =  Config::MQTT::log_topic + m_username + "/" + m_station_id;
 
     CryptoPP::SHA1 sha1;
     std::string source = username.toStdString()+m_station_id;  //This will be randomly generated somehow

--- a/source/library/src/mqtthandler.cpp
+++ b/source/library/src/mqtthandler.cpp
@@ -111,7 +111,6 @@ void MqttHandler::start(const QString& username, const QString& password){
 
     initialise(m_clientID);
 
-    mosquitto_loop_start(m_mqtt);
 
     mqttConnect();
 }
@@ -178,6 +177,8 @@ void MqttHandler::initialise(const std::string& client_id)
     mosquitto_connect_callback_set(m_mqtt, wrapper_callback_connected);
     mosquitto_disconnect_callback_set(m_mqtt, wrapper_callback_disconnected);
     mosquitto_message_callback_set(m_mqtt, wrapper_callback_message);
+
+    mosquitto_loop_start(m_mqtt);
 }
 
 void MqttHandler::cleanup() {
@@ -185,6 +186,8 @@ void MqttHandler::cleanup() {
         mqttDisconnect();
     }
     if (m_mqtt != nullptr) {
+        mosquitto_loop_stop(m_mqtt, true);
+
         mosquitto_destroy(m_mqtt);
         m_mqtt = nullptr;
         mosquitto_lib_cleanup();


### PR DESCRIPTION
There is still work to do.

For one the CMake configuration for windows will need to be checked in order to use libmosquitto instead of paho-mqttpp.

Also it needs to be tested.

This change also introduces a way to subscribe to topics instead of only publish them.