### PR TITLE
Fix text color for dark themes

### DIFF
--- a/gui/src/custom_histogram_widget.cpp
+++ b/gui/src/custom_histogram_widget.cpp
@@ -30,7 +30,7 @@ CustomHistogram::~CustomHistogram()
 void CustomHistogram::initialize()
 {
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-    setStyleSheet("background-color: white; border: 0px;");
+    setStyleSheet("background-color: white; color: black; border: 0px;");
     setAutoReplot(true);
     enableAxis(QwtPlot::yLeft, true);
     enableAxis(QwtPlot::yRight, false);

--- a/gui/src/custom_plot_widget.cpp
+++ b/gui/src/custom_plot_widget.cpp
@@ -30,7 +30,7 @@ CustomPlot::~CustomPlot()
 void CustomPlot::initialize()
 {
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-    setStyleSheet("background-color: white; border: 0px;");
+    setStyleSheet("background-color: white; color: black; border: 0px;");
     setAutoReplot(false);
     enableAxis(QwtPlot::yLeft, true);
     setAxisAutoScale(QwtPlot::xBottom, true);

--- a/gui/src/plotcustom.cpp
+++ b/gui/src/plotcustom.cpp
@@ -32,7 +32,7 @@ private:
 void PlotCustom::initialize()
 {
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-    setStyleSheet("background-color: white; border: 0px;");
+    setStyleSheet("background-color: white; color: black; border: 0px;");
     setAutoReplot(false);
     enableAxis(QwtPlot::yLeft, false);
     enableAxis(QwtPlot::yRight, true);

--- a/gui/src/status.cpp
+++ b/gui/src/status.cpp
@@ -62,7 +62,7 @@ Status::Status(QWidget* parent)
     timepulseTimer.setSingleShot(true);
     timepulseTimer.setInterval(3000);
     connect(&timepulseTimer, &QTimer::timeout, this, [this]() {
-        statusUi->timePulseLabel->setStyleSheet("QLabel {background-color: red;}");
+        statusUi->timePulseLabel->setStyleSheet("QLabel {background-color: red; color: black;}");
     });
 }
 
@@ -186,7 +186,7 @@ void Status::onTriggerSelectionReceived(GPIO_SIGNAL signal)
 
 void Status::onTimepulseReceived()
 {
-    statusUi->timePulseLabel->setStyleSheet("QLabel {background-color: lightGreen;}");
+    statusUi->timePulseLabel->setStyleSheet("QLabel {background-color: lightGreen; color: black;}");
     timepulseTimer.start();
 }
 
@@ -310,10 +310,10 @@ void Status::on_triggerSelectionComboBox_currentIndexChanged(const QString& arg1
 void Status::onMqttStatusChanged(bool connected)
 {
     if (connected) {
-        statusUi->mqttStatusLabel->setStyleSheet("QLabel {background-color: lightGreen;}");
+        statusUi->mqttStatusLabel->setStyleSheet("QLabel {background-color: lightGreen; color: black;}");
         statusUi->mqttStatusLabel->setText("MQTT: Connected");
     } else {
-        statusUi->mqttStatusLabel->setStyleSheet("QLabel {background-color: red;}");
+        statusUi->mqttStatusLabel->setStyleSheet("QLabel {background-color: red; color: black;}");
         statusUi->mqttStatusLabel->setText("MQTT: No Connection");
     }
 }
@@ -324,11 +324,11 @@ void Status::onMqttStatusChanged(MuonPi::MqttHandler::Status status)
     switch (status) {
     case MuonPi::MqttHandler::Status::Connected:
         status_string = "Connected";
-        statusUi->mqttStatusLabel->setStyleSheet("QLabel {background-color: lightGreen;}");
+        statusUi->mqttStatusLabel->setStyleSheet("QLabel {background-color: lightGreen; color: black;}");
         break;
     case MuonPi::MqttHandler::Status::Disconnecting:
     case MuonPi::MqttHandler::Status::Connecting:
-        statusUi->mqttStatusLabel->setStyleSheet("QLabel {background-color: yellow;}");
+        statusUi->mqttStatusLabel->setStyleSheet("QLabel {background-color: yellow; color: black;}");
         status_string = "Connecting/Disconnecting";
         break;
     case MuonPi::MqttHandler::Status::Disconnected:
@@ -338,7 +338,7 @@ void Status::onMqttStatusChanged(MuonPi::MqttHandler::Status status)
     case MuonPi::MqttHandler::Status::Error:
     default:
         status_string = "Error";
-        statusUi->mqttStatusLabel->setStyleSheet("QLabel {background-color: red;}");
+        statusUi->mqttStatusLabel->setStyleSheet("QLabel {background-color: red; color: black;}");
     };
     statusUi->mqttStatusLabel->setText("MQTT: " + status_string);
 }


### PR DESCRIPTION
Intended to fix the bug I described in issue #74. Unfortunately, I couldn't build the GUI from source on macOS to test if these changes work or break anything (I'm struggling to install the `qwt` dependency), so somebody should review it. I also don't know if the plot axes and ticks are fixed with this. According to [this forum post](https://www.qtcentre.org/threads/30696-Change-the-color-of-the-qwt-plot-axis-numbers-and-ticks?s=4ccf0a511ba2e05a5317f1098b6bdc0a&p=143336#post143336), they should be.