### PR TITLE
Fix log formatting; improving machine readability

### DIFF
--- a/daemon/src/daemon.cpp
+++ b/daemon/src/daemon.cpp
@@ -2127,7 +2127,7 @@ void Daemon::UBXReceivedVersion(const QString& swString, const QString& hwString
     TcpMessage tcpMessage(TCP_MSG_KEY::MSG_UBX_VERSION);
     (*tcpMessage.dStream) << swString << hwString << protString;
     emit sendTcpMessage(tcpMessage);
-    emit logParameter(LogParameter("UBX_SW_Version", swString, LogParameter::LOG_ONCE));
+    emit logParameter(LogParameter("UBX_SW_Version", QString("\"%1\"").arg(swString), LogParameter::LOG_ONCE));
     emit logParameter(LogParameter("UBX_HW_Version", hwString, LogParameter::LOG_ONCE));
     emit logParameter(LogParameter("UBX_Prot_Version", protString, LogParameter::LOG_ONCE));
     if (initialVersionInfo) {

--- a/daemon/src/daemon.cpp
+++ b/daemon/src/daemon.cpp
@@ -2033,9 +2033,9 @@ void Daemon::gpsPropertyUpdatedUint8(uint8_t data, std::chrono::duration<double>
         emit sendTcpMessage(*tcpMessage);
         delete tcpMessage;
         emit logParameter(LogParameter("fixStatus", QString::number(data), LogParameter::LOG_LATEST));
-        emit logParameter(LogParameter("fixStatusString", QString::fromLocal8Bit(Gnss::FixType::name_log_safe[data]), LogParameter::LOG_LATEST));
+        emit logParameter(LogParameter("fixStatusString", QString::fromLocal8Bit(Gnss::FixType::name[data]), LogParameter::LOG_LATEST));
         fixStatus = QVariant(data);
-        propertyMap["fixStatus"] = Property("fixStatus", QString::fromLocal8Bit(Gnss::FixType::name_log_safe[data]));
+        propertyMap["fixStatus"] = Property("fixStatus", QString::fromLocal8Bit(Gnss::FixType::name[data]));
         break;
     default:
         break;

--- a/daemon/src/daemon.cpp
+++ b/daemon/src/daemon.cpp
@@ -2033,9 +2033,9 @@ void Daemon::gpsPropertyUpdatedUint8(uint8_t data, std::chrono::duration<double>
         emit sendTcpMessage(*tcpMessage);
         delete tcpMessage;
         emit logParameter(LogParameter("fixStatus", QString::number(data), LogParameter::LOG_LATEST));
-        emit logParameter(LogParameter("fixStatusString", QString::fromLocal8Bit(Gnss::FixType::name[data]), LogParameter::LOG_LATEST));
+        emit logParameter(LogParameter("fixStatusString", QString::fromLocal8Bit(Gnss::FixType::name_log_safe[data]), LogParameter::LOG_LATEST));
         fixStatus = QVariant(data);
-        propertyMap["fixStatus"] = Property("fixStatus", QString::fromLocal8Bit(Gnss::FixType::name[data]));
+        propertyMap["fixStatus"] = Property("fixStatus", QString::fromLocal8Bit(Gnss::FixType::name_log_safe[data]));
         break;
     default:
         break;

--- a/daemon/src/utility/filehandler.cpp
+++ b/daemon/src/utility/filehandler.cpp
@@ -257,9 +257,9 @@ bool FileHandler::openFiles(bool writeHeader)
     // write header
     if (writeHeader) {
         QTextStream dataOut(dataFile);
-        dataOut << "#unix_timestamp_rising(s)  unix_timestamp_trailing(s)  time_accuracy(ns)  valid  timebase(0=gps,2=utc)  utc_available\n";
+        dataOut << "#unix_timestamp_rising(s) unix_timestamp_trailing(s) time_accuracy(ns) valid timebase(0=gps,2=utc) utc_available\n";
         QTextStream logOut(logFile);
-        logOut << "#log parameters: time<YYYY-MM-DD_hh-mm-ss>  parname   value  unit\n";
+        logOut << "#time<YYYY-MM-DD_hh-mm-ss> parname value unit\n";
     }
     emit logRotateSignal();
     return true;

--- a/library/include/ublox_structs.h
+++ b/library/include/ublox_structs.h
@@ -42,8 +42,7 @@ struct FixType {
         first = None,
         last = Undefined
     };
-    static constexpr std::array<const char*, last + 1> name { "No Fix", "Dead Reck.", "2D-Fix", "3D-Fix", "GPS+Dead Reck.", "Time Fix", " N/A" };
-    static constexpr std::array<const char*, last + 1> name_log_safe { "NoFix", "DeadReck", "2D", "3D", "GPS+DeadReck", "TimeFix", "N/A" };
+    static constexpr std::array<const char*, last + 1> name { "NoFix", "DeadReck", "2D", "3D", "GPS+DeadReck", "TimeFix", "N/A" };
 };
 
 struct OrbitSource {

--- a/library/include/ublox_structs.h
+++ b/library/include/ublox_structs.h
@@ -43,6 +43,7 @@ struct FixType {
         last = Undefined
     };
     static constexpr std::array<const char*, last + 1> name { "No Fix", "Dead Reck.", "2D-Fix", "3D-Fix", "GPS+Dead Reck.", "Time Fix", " N/A" };
+    static constexpr std::array<const char*, last + 1> name_log_safe { "NoFix", "DeadReck", "2D", "3D", "GPS+DeadReck", "TimeFix", "N/A" };
 };
 
 struct OrbitSource {


### PR DESCRIPTION
Fixing some issues I encountered while reading log and data files into `pd.DataFrame`, where two whitespaces in the header lead to a column names getting assigned to the wrong data. 
